### PR TITLE
Update Gemfile to use secure rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "rake"
 gem "activesupport"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
       thor (>= 0.14.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.9)
       i18n (~> 0.6)


### PR DESCRIPTION
`Gemfile` still contained an unsafe source. Updated it to use https://rubygems.org.
